### PR TITLE
Ensure value init uses the type constructor

### DIFF
--- a/dataclasses_struct/dataclass.py
+++ b/dataclasses_struct/dataclass.py
@@ -113,7 +113,7 @@ class _DataclassStructInternal(Generic[T]):
             if is_dataclass_struct(fieldtype):
                 yield fieldtype.__dataclass_struct__._init_from_args(args)
             else:
-                yield next(args)
+                yield fieldtype(next(args))
 
     def _init_from_args(self, args: Iterator) -> T:
         """


### PR DESCRIPTION
This means that when you use custom types such as Enum or Flag, they will be initialised properly when deserialized.

Using a struct like this:
```py
@dataclass()
class MyStruct:
    PropertyFlags: Annotated[EPropertyFlags, field.UnsignedIntField(8)]
```
Previously once deserialized this would result in a plain `int` in the `PropertyFlags` property.

After this change it contains a properly initialized enum, allowing it to display for example as the following in repr:
```
PropertyFlags=<EPropertyFlags.Edit|NativeAccessSpecifierPublic: 4503599627370497>
```