### PR TITLE
Support kw_only

### DIFF
--- a/dataclasses_struct/dataclass.py
+++ b/dataclasses_struct/dataclass.py
@@ -149,7 +149,14 @@ class _DataclassStructInternal(Generic[T]):
         """
         Returns an instance of self.cls, consuming args
         """
-        return self.cls(*self._arg_generator(args))
+        return self.cls(
+            **{
+                fieldname: arg
+                for fieldname, arg in zip(
+                    self._fieldnames, self._arg_generator(args)
+                )
+            }
+        )
 
     def unpack(self, data: bytes) -> T:
         return self._init_from_args(iter(self.struct.unpack(data)))

--- a/dataclasses_struct/dataclass.py
+++ b/dataclasses_struct/dataclass.py
@@ -23,6 +23,16 @@ from ._typing import TypeGuard, Unpack, dataclass_transform
 from .field import Field, builtin_fields
 from .types import PadAfter, PadBefore
 
+if sys.version_info >= (3, 10):
+    from dataclasses import KW_ONLY as _KW_ONLY_MARKER
+else:
+    # Placeholder for KW_ONLY on Python 3.9
+
+    class _KW_ONLY_MARKER_TYPE:
+        pass
+
+    _KW_ONLY_MARKER = _KW_ONLY_MARKER_TYPE()
+
 
 def _separate_padding_from_annotation_args(args) -> tuple[int, int, object]:
     pad_before = pad_after = 0
@@ -434,6 +444,10 @@ def _make_class(
     struct_format = [mode]
     fields = []
     for name, field in cls_annotations.items():
+        if field is _KW_ONLY_MARKER:
+            # KW_ONLY is handled by stdlib dataclass, nothing to do on our end.
+            continue
+
         fmt, field, type_ = _validate_and_parse_field(
             cls,
             name=name,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import Iterable
 from typing import Callable, List  # noqa: UP035
 
@@ -100,3 +101,9 @@ def parametrize_all_list_types() -> ParametrizeDecorator:
         )(f)
 
     return mark
+
+
+skipif_kw_only_not_supported = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="kw_only added in Python 3.10",
+)

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -16,6 +16,7 @@ from conftest import (
     parametrize_all_sizes_and_byteorders,
     parametrize_fields,
     parametrize_std_byteorders,
+    skipif_kw_only_not_supported,
     std_only_int_fields,
 )
 
@@ -608,3 +609,19 @@ def test_str_type_annotations() -> None:
         k: "dcs.F32"
         l: "dcs.F64"  # noqa: E741
         m: "Annotated[bytes, 10]"
+
+
+@skipif_kw_only_not_supported
+def test_kw_only_marker() -> None:
+    from dataclasses import KW_ONLY  # type: ignore
+
+    @dcs.dataclass_struct()
+    class T:
+        arg1: int
+        arg2: int
+        _: KW_ONLY
+        kwarg1: float
+        kwarg2: bool
+
+    with pytest.raises(TypeError):
+        T(1, 2, 1.2, False)  # type: ignore

--- a/test/test_pack_unpack.py
+++ b/test/test_pack_unpack.py
@@ -1,6 +1,5 @@
 import itertools
 import struct
-import sys
 from typing import Annotated
 
 import pytest
@@ -14,6 +13,7 @@ from conftest import (
     parametrize_all_sizes_and_byteorders,
     parametrize_fields,
     parametrize_std_byteorders,
+    skipif_kw_only_not_supported,
     std_byteorders,
     std_only_int_fields,
 )
@@ -461,12 +461,6 @@ def test_unpack_padding(size, byteorder) -> None:
         b"\x00" + (b"\x00" * 4) + b"\x01" + (b"\x00" * 7)
     )
     assert unpacked == Test(False, True)
-
-
-skipif_kw_only_not_supported = pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="kw_only added in Python 3.10",
-)
 
 
 @skipif_kw_only_not_supported


### PR DESCRIPTION
- **Support kw_only in Python 3.10 and higher**
- **Support dataclasses.KW_ONLY in Python 3.10**
