### PR TITLE
Support ClassVars

### DIFF
--- a/dataclasses_struct/dataclass.py
+++ b/dataclasses_struct/dataclass.py
@@ -1,5 +1,6 @@
 import dataclasses
 import sys
+import warnings
 from collections.abc import Generator, Iterator
 from struct import Struct
 from typing import (
@@ -21,7 +22,7 @@ from typing import (
 
 from ._typing import Buffer, TypeGuard, Unpack, dataclass_transform
 from .field import Field, builtin_fields
-from .types import NullTerminated, PadAfter, PadBefore
+from .types import NullTerminated, PadAfter, PadBefore, _Padding
 
 if sys.version_info >= (3, 10):
     from dataclasses import KW_ONLY as _KW_ONLY_MARKER
@@ -543,6 +544,24 @@ def from_packed(cls, data: Buffer) -> cls_type:
     return classmethod(scope["from_packed"])
 
 
+def _check_class_var(name: str, field: Any) -> None:
+    classvar_args = get_args(field)
+    assert len(classvar_args) == 1
+    classvar_arg = classvar_args[0]
+    if get_origin(classvar_arg) is not Annotated:
+        return
+
+    for arg in get_args(classvar_arg):
+        if isinstance(arg, (Field, _Padding)):
+            msg = (
+                f"field '{name}' is a ClassVar, but is annotated with a "
+                "dataclass_struct field type; ClassVars are not included in "
+                "the packed representation."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=4)
+            return
+
+
 def _make_class(
     cls: type,
     mode: str,
@@ -557,6 +576,12 @@ def _make_class(
     for name, field in cls_annotations.items():
         if field is _KW_ONLY_MARKER:
             # KW_ONLY is handled by stdlib dataclass, nothing to do on our end.
+            continue
+
+        if field is ClassVar:
+            continue
+        if get_origin(field) == ClassVar:
+            _check_class_var(name, field)
             continue
 
         fmt, field = _validate_and_parse_field(

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -502,6 +502,40 @@ b'\x00\x00\x00\x00d\x00\x00\x00\xc8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00,
 WithPadding(pad_before=100, pad_after=200, pad_before_and_after=300)
 ```
 
+## Class variables
+
+Fields annotated with `typing.ClassVar` behave exactly as in a stdlib
+`dataclass`. In particular, they are excluded from the packed representation:
+
+```python
+from typing import ClassVar
+
+@dcs.dataclass_struct(size="std")
+class WithClassVar:
+    x: dcs.U8
+    label: ClassVar[str] = "example"
+    y: dcs.U8
+```
+
+```python
+>>> WithClassVar.label
+'example'
+>>> t = WithClassVar(1, 2)
+>>> t.label
+'example'
+>>> t.pack()
+b'\x01\x02'
+>>> unpacked = WithClassVar.from_packed(b'\x01\x02')
+>>> unpacked
+WithClassVar(x=1, y=2)
+>>> unpacked.label
+'example'
+```
+
+`ClassVar` fields annotated with `dataclasses_struct` fields (e.g. `dcs.U16`)
+will emit a `UserWarning` and be treated as regular `ClassVar` fields that are
+not included in the packed representation.
+
 ## Type checking
 
 ### Mypy

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -3,7 +3,7 @@ import itertools
 import re
 from contextlib import contextmanager
 from re import escape
-from typing import Annotated
+from typing import Annotated, Any, ClassVar
 
 import pytest
 from conftest import (
@@ -512,3 +512,56 @@ def test_kw_only_marker() -> None:
 
     with pytest.raises(TypeError):
         T(1, 2, 1.2, False)  # type: ignore
+
+
+@parametrize_all_sizes_and_byteorders()
+def test_class_var_ignored(size, byteorder) -> None:
+    @dcs.dataclass_struct(size=size, byteorder=byteorder)
+    class T:
+        x: bytes
+        y: ClassVar[str] = "Hello, world!"
+        z: bytes
+
+    t = T(b"a", b"c")
+    assert t.x == b"a"
+    assert t.y == "Hello, world!"
+    assert t.z == b"c"
+
+
+@parametrize_all_sizes_and_byteorders()
+def test_class_var_without_arg_ignored(size, byteorder) -> None:
+    @dcs.dataclass_struct(size=size, byteorder=byteorder)
+    class T:
+        x: bytes
+        y: ClassVar = "Hello, world!"
+        z: bytes
+
+    t = T(b"a", b"c")
+    assert t.x == b"a"
+    assert t.y == "Hello, world!"
+    assert t.z == b"c"
+
+
+def test_dcs_type_in_class_var_raises_warning() -> None:
+    msg = (
+        "field 'x' is a ClassVar, but is annotated with a dataclass_struct "
+        "field type; ClassVars are not included in the packed representation."
+    )
+    with pytest.warns(UserWarning, match=rf"^{re.escape(msg)}$"):
+
+        @dcs.dataclass_struct(size="std")
+        class _:
+            x: ClassVar[dcs.U16] = 100
+
+
+@pytest.mark.parametrize("padding_type", (dcs.PadAfter, dcs.PadBefore))
+def test_padding_in_class_var_raises_warning(padding_type: Any) -> None:
+    msg = (
+        "field 'y' is a ClassVar, but is annotated with a dataclass_struct "
+        "field type; ClassVars are not included in the packed representation."
+    )
+    with pytest.warns(UserWarning, match=rf"^{re.escape(msg)}$"):
+
+        @dcs.dataclass_struct(size="native")
+        class _:
+            y: ClassVar[Annotated[int, padding_type(10)]] = 100

--- a/test/test_pack_unpack.py
+++ b/test/test_pack_unpack.py
@@ -3,7 +3,7 @@ import itertools
 import mmap
 import struct
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 import pytest
 from conftest import (
@@ -759,3 +759,23 @@ def test_pack_unpack_mmap(tmp_path: Path) -> None:
 
     # Check that the file isn't changed
     assert path.read_bytes() == packed
+
+
+@parametrize_all_sizes_and_byteorders()
+def test_class_var_not_in_packed_data(size, byteorder) -> None:
+    @dcs.dataclass_struct(size=size, byteorder=byteorder)
+    class T:
+        y: ClassVar[str] = "Hello, world!"
+
+    t = T()
+    assert t.pack() == b""
+
+
+@parametrize_all_sizes_and_byteorders()
+def test_class_var_not_in_unpacked_data(size, byteorder) -> None:
+    @dcs.dataclass_struct(size=size, byteorder=byteorder)
+    class T:
+        y: ClassVar[str] = "Hello, world!"
+
+    unpacked = T.from_packed(b"")
+    assert unpacked.y == "Hello, world!"


### PR DESCRIPTION
Closes #31

Like in stdlib dataclasses, fields annotated with `ClassVar` are ignored. If a `dataclasses_struct` type is used as the argument to a `ClassVar`, then a `UserWarning` will be raised reminding the user that the field is not included in the packed representation.